### PR TITLE
Header added:

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -133,10 +133,12 @@ func (s *gatewayResource) configHandler(w http.ResponseWriter, r *http.Request) 
 		s.httpError(w, http.StatusInternalServerError, "Config unavailable")
 		return
 	}
+
 	// Make expiration time even/random throughout interval 12-36h
 	// So the avg will be 24h but without spikes of the requests for the key renewal
 	rand.Seed(time.Now().UnixNano())
 	maxAge := 12*3600 + rand.Intn(24*3600)
 	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, private", maxAge))
+
 	w.Write(config.Marshal())
 }

--- a/gateway.go
+++ b/gateway.go
@@ -6,11 +6,12 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/chris-wood/ohttp-go"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net/http"
-
-	"github.com/chris-wood/ohttp-go"
+	"time"
 )
 
 type TargetFilter func(targetOrigin string) bool
@@ -132,6 +133,10 @@ func (s *gatewayResource) configHandler(w http.ResponseWriter, r *http.Request) 
 		s.httpError(w, http.StatusInternalServerError, "Config unavailable")
 		return
 	}
-
+	// Make expiration time even/random throughout interval 12-36h
+	// So the avg will be 24h but without spikes of the requests for the key renewal
+	rand.Seed(time.Now().UnixNano())
+	maxAge := 12*3600 + rand.Intn(24*3600)
+	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, private", maxAge))
 	w.Write(config.Marshal())
 }

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -6,15 +6,15 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"github.com/chris-wood/ohttp-go"
+	"github.com/cisco/go-hpke"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
-
-	"github.com/chris-wood/ohttp-go"
-	"github.com/cisco/go-hpke"
 )
 
 var (
@@ -110,6 +110,23 @@ func TestConfigHandler(t *testing.T) {
 
 	if !bytes.Equal(body, marshalledConfig) {
 		t.Fatal("Received invalid config")
+	}
+
+	// checking correct header exists
+	// Cache-Control: max-age=%d, private
+	cctrl := rr.Header().Get("Cache-Control")
+
+	if strings.HasPrefix(cctrl, "max-age=") && strings.HasSuffix(cctrl, ", private") {
+		maxAge := strings.TrimPrefix(strings.TrimSuffix(cctrl, ", private"), "max-age=")
+		age, err := strconv.Atoi(maxAge)
+		if err != nil {
+			t.Fatal("max-age value should be int", err)
+		}
+		if age < 12*3600 || age > 36*3600 {
+			t.Fatal("age should be between 12 and 36 hours")
+		}
+	} else {
+		t.Fatal("Cache-Control format should be 'max-age=86400, private'")
 	}
 }
 


### PR DESCRIPTION
Cache-Control: max-age=%d, private

// Make expiration time even/random throughout interval 12-36h
// So the avg will be 24h but without spikes of the requests for the key renewal